### PR TITLE
Feat/check updates

### DIFF
--- a/__tests__/update.service.test.ts
+++ b/__tests__/update.service.test.ts
@@ -1,0 +1,72 @@
+import { UpdateService } from '../src/services/update.service';
+import { HttpsService } from '../src/services/https.service';
+
+describe('update Service', () => {
+  let updateService: UpdateService;
+  let httpsService: HttpsService;
+
+  beforeEach(() => {
+    httpsService = new HttpsService();
+    updateService = new UpdateService(httpsService);
+  });
+
+  describe('#isUpdated', () => {
+    const localVersion = '2.3.6';
+    const cases = [
+      {
+        isUpdated: true,
+        remoteVersion: '2.3.6',
+      },
+      {
+        isUpdated: true,
+        remoteVersion: '0.3.6',
+      },
+      {
+        isUpdated: true,
+        remoteVersion: '0.2.1',
+      },
+      {
+        isUpdated: true,
+        remoteVersion: '2.2.1',
+      },
+      {
+        isUpdated: true,
+        remoteVersion: '2.3.5',
+      },
+      {
+        isUpdated: true,
+        remoteVersion: '0.2.53',
+      },
+      {
+        isUpdated: true,
+        remoteVersion: '0.2.53',
+      },
+      {
+        isUpdated: false,
+        remoteVersion: '2.3.61',
+      },
+      {
+        isUpdated: false,
+        remoteVersion: '2.3.7',
+      },
+      {
+        isUpdated: false,
+        remoteVersion: '4.74.452',
+      },
+    ];
+
+    cases.forEach(cas => {
+      it(`should check the local version ${localVersion} is up to date with the remote ${cas.remoteVersion}`, done => {
+        const mockResponse = `{"last-recomended-version": "${cas.remoteVersion}"}`;
+        httpsService.get = jest
+          .fn()
+          .mockImplementation(() => Promise.resolve(JSON.parse(mockResponse)));
+
+        updateService.isUpdated(localVersion).then(isUpdated => {
+          expect(isUpdated).toBe(cas.isUpdated);
+          done();
+        });
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "typescript": "^3.4.5",
+    "tslint": "^5.18.0",
     "ts-node": "^8.3.0",
     "commitlint": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",

--- a/src/constants/main.constants.ts
+++ b/src/constants/main.constants.ts
@@ -32,6 +32,7 @@ export const UI_HELP = {
 export const UI_POSITIONS: IUiPosition = {
   FOLDER_SIZE_HEADER: { x: -1, y: 7 }, // x is calculated in controller
   INITIAL: { x: 0, y: 0 },
+  NEW_UPDATE_FOUND: { x: 42, y: 0 },
   SPACE_RELEASED: { x: 50, y: 4 },
   STATUS: { x: 50, y: 5 },
   TOTAL_SPACE: { x: 50, y: 3 },

--- a/src/constants/messages.constants.ts
+++ b/src/constants/messages.constants.ts
@@ -10,6 +10,7 @@ export const INFO_MSGS = {
   MIN_CLI_CLOMUNS:
     'Oh no! The terminal is too narrow. Please, ' +
     'enlarge it (This will be fixed in future versions. Disclose the inconveniences)',
+  NEW_UPDATE_FOUND: 'New version found! npm i -g npkill for update.',
   SEARCHING: 'searching ',
   SEARCH_COMPLETED: 'search completed ',
   SPACE_RELEASED: 'space saved: ',

--- a/src/constants/messages.constants.ts
+++ b/src/constants/messages.constants.ts
@@ -16,3 +16,7 @@ export const INFO_MSGS = {
   SPACE_RELEASED: 'space saved: ',
   TOTAL_SPACE: 'releasable space: ',
 };
+
+export const ERROR_MSG = {
+  CANT_GET_REMOTE_VERSION: 'Couldnt check for updates',
+};

--- a/src/constants/update.constants.ts
+++ b/src/constants/update.constants.ts
@@ -1,0 +1,2 @@
+export const VERSION_CHECK_DIRECTION = 'https://zaldih.tk/npkill/version.json';
+export const VERSION_KEY = 'last-recomended-version';

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -17,7 +17,11 @@ import {
   UI_POSITIONS,
   VALID_KEYS,
 } from './constants/main.constants';
-import { HELP_MSGS, INFO_MSGS } from './constants/messages.constants';
+import {
+  HELP_MSGS,
+  INFO_MSGS,
+  ERROR_MSG,
+} from './constants/messages.constants';
 import { SPINNERS, SPINNER_INTERVAL } from './constants/spinner.constants';
 import { Subject, interval } from 'rxjs';
 
@@ -101,6 +105,11 @@ export class Controller {
       .isUpdated(this.getVersion())
       .then((isUpdated: boolean) => {
         if (!isUpdated) this.showNewInfoMessage();
+      })
+      .catch(err => {
+        const errorMessage =
+          ERROR_MSG.CANT_GET_REMOTE_VERSION + ': ' + err.message;
+        this.printError(errorMessage);
       });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,12 @@ import { Controller } from './controller';
 import { ConsoleService } from './services/console.service';
 import { FileService } from './services/files.service';
 import { SpinnerService } from './services/spinner.service';
+import { UpdateService } from './services/update.service';
+import { HttpsService } from './services/https.service';
 
 const controller = new Controller(
   new ConsoleService(),
   new FileService(),
   new SpinnerService(),
+  new UpdateService(new HttpsService()),
 );

--- a/src/interfaces/version.interface.ts
+++ b/src/interfaces/version.interface.ts
@@ -1,0 +1,5 @@
+export interface IVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}

--- a/src/services/https.service.ts
+++ b/src/services/https.service.ts
@@ -2,8 +2,13 @@ import * as https from 'https';
 
 export class HttpsService {
   get(url: string): Promise<{}> {
-    return new Promise((resolve, rejects) => {
+    return new Promise((resolve, reject) => {
       https.get(url, res => {
+        if (!this.isCorrectResponse(res.statusCode)) {
+          reject(new Error(res.statusMessage));
+          return;
+        }
+
         res.setEncoding('utf8');
         let body = '';
         res.on('data', data => {
@@ -14,5 +19,11 @@ export class HttpsService {
         });
       });
     });
+  }
+
+  private isCorrectResponse(statusCode: number): boolean {
+    const correctRangeStart = 200;
+    const correctRangeEnd = 299;
+    return statusCode >= correctRangeStart && statusCode <= correctRangeEnd;
   }
 }

--- a/src/services/https.service.ts
+++ b/src/services/https.service.ts
@@ -1,0 +1,18 @@
+import * as https from 'https';
+
+export class HttpsService {
+  get(url: string): Promise<{}> {
+    return new Promise((resolve, rejects) => {
+      https.get(url, res => {
+        res.setEncoding('utf8');
+        let body = '';
+        res.on('data', data => {
+          body += data;
+        });
+        res.on('end', () => {
+          resolve(JSON.parse(body));
+        });
+      });
+    });
+  }
+}

--- a/src/services/update.service.ts
+++ b/src/services/update.service.ts
@@ -1,0 +1,63 @@
+import { HttpsService } from './https.service';
+import {
+  VERSION_CHECK_DIRECTION,
+  VERSION_KEY,
+} from '../constants/update.constants';
+import { IVersion } from '../interfaces/version.interface';
+
+export class UpdateService {
+  constructor(private httpsService: HttpsService) {}
+
+  async isUpdated(localVersion: string): Promise<boolean> {
+    const remoteVersion = await this.getRemoteVersion();
+
+    const local = this.splitVersion(localVersion);
+    const remote = this.splitVersion(remoteVersion);
+
+    return this.compareVersions(local, remote);
+  }
+
+  private compareVersions(local: IVersion, remote: IVersion): boolean {
+    return (
+      this.isSameVersion(local, remote) ||
+      this.isLocalVersionGreater(local, remote)
+    );
+  }
+
+  private async getRemoteVersion(): Promise<string> {
+    const response: {} = await this.httpsService.get(VERSION_CHECK_DIRECTION);
+    return response[VERSION_KEY];
+  }
+
+  private splitVersion(version: string): IVersion {
+    const versionSeparator = '.';
+    const remoteSplited = version.split(versionSeparator);
+    return {
+      major: +remoteSplited[0],
+      minor: +remoteSplited[1],
+      patch: +remoteSplited[2],
+    };
+  }
+
+  private isSameVersion(version1: IVersion, version2: IVersion): boolean {
+    return JSON.stringify(version1) === JSON.stringify(version2);
+  }
+
+  private isLocalVersionGreater(local: IVersion, remote: IVersion): boolean {
+    return (
+      this.isMajorGreater(local.major, remote.major) ||
+      this.isMinorGreater(local.minor, remote.minor) ||
+      this.isPatchGreater(local.patch, remote.patch)
+    );
+  }
+
+  private isMajorGreater(localMajor: number, remoteMajor: number): boolean {
+    return localMajor > remoteMajor;
+  }
+  private isMinorGreater(localMinor: number, remoteMinor: number): boolean {
+    return localMinor > remoteMinor;
+  }
+  private isPatchGreater(localPatch: number, remotePatch: number): boolean {
+    return localPatch > remotePatch;
+  }
+}


### PR DESCRIPTION
This feature gives npkill the ability to check for newer versions. To do this, npkill obtains a remote json containing the latest version and compares it with that of the local program.

For now, the version is consulted from [this url](https://zaldih.tk/npkill/version.json)

Maybe it's a good idea to comment about this functionality in the readme.

**TODO**

- [x] Error control: throw any possible fetch error with a descriptive description